### PR TITLE
YML with redone whitespace

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,45 +1,45 @@
 spring:
-  application:
-    name: screenforce-gateway
-  cloud:
-    gateway:
-      discovery:
-        locator:
-          enabled: true
-      routes:
-      - id: tech-screening-service
-        uri: lb://tech-screening-service
-        predicates:
-        - Path=/screening/**
-        filters:
-        - RewritePath=/screening/(?<path>.*), /$\{path}
-      - id: screening-admin-service
-        uri: lb://screening-admin-service
-        predicates:
-        - Path=/admin/**
-        filters:
-        - RewritePath=/admin/(?<path>.*), /$\{path}
-      - id: report-screening-service
-        uri: lb://report-screening-service
-        predicates:
-        - Path=/report/**
-        filters:
-        - RewritePath=/report/(?<path>.*), /$\{path}       
-    config:
-      uri: http://localhost:8080
+    application:
+        name: screenforce-gateway
+    cloud:
+        gateway:
+            discovery:
+                locator:
+                    enabled: true
+                    routes:
+                    - id: tech-screening-service
+                      uri: lb://tech-screening-service
+                      predicates:
+                      - Path=/screening/**
+                      filters:
+                      - RewritePath=/screening/(?<path>.*), /$\{path}
+                    - id: screening-admin-service
+                      uri: lb://screening-admin-service
+                      predicates:
+                      - Path=/admin/**
+                      filters:
+                      - RewritePath=/admin/(?<path>.*), /$\{path}
+                    - id: report-screening-service
+                      uri: lb://report-screening-service
+                      predicates:
+                      - Path=/report/**
+                      filters:
+                      - RewritePath=/report/(?<path>.*), /$\{path}       
+                    config:
+                      uri: http://localhost:8080
       
 server:
-  port: 8080
+    port: 8080
   
 security:
-  basic:
-    enabled: false
+    basic:
+        enabled: false
 
 management:
-  security:
-    enabled: false
+    security:
+        enabled: false
 
 eureka:
-  client:
-    service-url:
-      defaultZone: ${CALIBER_EUREKA_SERVER_URL}
+    client:
+        service-url:
+            defaultZone: ${CALIBER_EUREKA_SERVER_URL}


### PR DESCRIPTION
whitespacing structure I found to be the most clear and readable was as follows: every YML file begins with the Spring line, to make them all uniform; every main line starts without whitespace; then every additional line beneath the main line gets 4 whitespaces per line, this process continues for however many additional lines a given main line may need; if any comments are added to the document, the # begins at the 3rd whitespace, and the whitespace following the hashtag is as it should be if the # was not there (i.e. 4 white spaces for every line after the first)